### PR TITLE
short form type annotation may appear on the same line as the close parenthesis

### DIFF
--- a/bin/check_mypy_annotations.py
+++ b/bin/check_mypy_annotations.py
@@ -109,6 +109,11 @@ def process_source(lines, added_lines, line_to_func_map):
         if source_utils.is_line_annotated(first_line):
             continue
 
+        end_line_of_def = lines[first_line_num - 1]
+        function_definition, rest = end_line_of_def.split(':', 1)
+        if source_utils.is_line_annotated(rest):
+            continue
+
         results.append(first_line_num)
         printed_funcs.add(func_def)
     return results

--- a/bin/check_mypy_annotations.py
+++ b/bin/check_mypy_annotations.py
@@ -104,15 +104,6 @@ def process_source(lines, added_lines, line_to_func_map):
             continue
 
         first_line_num = source_utils.find_first_line_of_func(lines, func_def.lineno)
-        first_line = lines[first_line_num]
-
-        if source_utils.is_line_annotated(first_line):
-            continue
-
-        end_line_of_def = lines[first_line_num - 1]
-        function_definition, rest = end_line_of_def.split(':', 1)
-        if source_utils.is_line_annotated(rest):
-            continue
 
         results.append(first_line_num)
         printed_funcs.add(func_def)

--- a/mypytools/source_utils.py
+++ b/mypytools/source_utils.py
@@ -55,11 +55,15 @@ def find_first_line_of_func(lines, line_num):
 def is_line_annotated(line):
     # type: (str) -> bool
     result = TYPE_PATTERN.search(line)
+
     return result is not None
 
 
 def is_func_def_annotated(func, lines):
     # type: (ast.FunctionDef, List[str]) -> bool
+    """ Produce True if either Python3 or Python2 style type annotations found
+    for the given function
+    """
     if getattr(func, 'returns', None):
         return True
 
@@ -69,7 +73,21 @@ def is_func_def_annotated(func, lines):
 
     first_line_num = find_first_line_of_func(lines, func.lineno)
     first_line = lines[first_line_num]
-    return is_line_annotated(first_line)
+    if is_line_annotated(first_line):
+        return True
+
+    first_line_num = find_first_line_of_func(lines, func.lineno)
+    first_line = lines[first_line_num]
+
+    if is_line_annotated(first_line):
+        return True
+
+    end_line_of_def = lines[first_line_num - 1]
+    function_definition, rest = end_line_of_def.split(':', 1)
+    if is_line_annotated(rest):
+        return True
+
+    return False
 
 
 def parse_source(source):

--- a/mypytools/source_utils.py
+++ b/mypytools/source_utils.py
@@ -76,12 +76,6 @@ def is_func_def_annotated(func, lines):
     if is_line_annotated(first_line):
         return True
 
-    first_line_num = find_first_line_of_func(lines, func.lineno)
-    first_line = lines[first_line_num]
-
-    if is_line_annotated(first_line):
-        return True
-
     end_line_of_def = lines[first_line_num - 1]
     function_definition, rest = end_line_of_def.split(':', 1)
     if is_line_annotated(rest):

--- a/tests/test_check_mypy_annotations.py
+++ b/tests/test_check_mypy_annotations.py
@@ -99,3 +99,13 @@ def foo(a: int, b) -> int:
     """
     error_lines = get_error_lines(source, {3})
     assert error_lines == []
+
+
+def test_short_form_close_parenthesis_line():
+    # type: () -> None
+    source = """
+def foo(a, b):  # type: (int, int) -> int
+    return a + b
+    """
+    error_lines = get_error_lines(source, {3})
+    assert error_lines == []


### PR DESCRIPTION
Per PEP-0484: 

> The short form may also occur on the same line as the close parenthesis, e.g.:
> 
> def add(a, b):  # type: (int, int) -> int
>     return a + b