### PR TITLE
Return exit_code from MypyTask

### DIFF
--- a/mypytools/server/mypy_task.py
+++ b/mypytools/server/mypy_task.py
@@ -42,7 +42,7 @@ def which(program):
 
 class MypyTask(object):
     def __init__(self, filename, include_error_context=True):
-        # type: (str) -> None
+        # type: (str, bool) -> None
         self.filename = filename
         self._proc = None   # type: Optional[Popen]
         self.include_error_context = include_error_context
@@ -60,7 +60,7 @@ class MypyTask(object):
             return hashlib.md5(f.read()).hexdigest()
 
     def execute(self):
-        # type: () -> Tuple[str, str, str]
+        # type: () -> Tuple[int, str, str, str]
         mypy_path = os.pathsep.join(os.path.join(config['root_dir'], path) for path in config.get('mypy_path', []))
         flags = ' '.join(config.get('global_flags', []))
         strict_optional = '--strict-optional' if self._should_use_strict_optional(self.filename) else ''
@@ -84,15 +84,16 @@ class MypyTask(object):
                 after_file_hash = self._get_file_hash()
 
             if exit_code == 0:
-                return '', '', before_file_hash
+                return 0, '', '', before_file_hash
 
             context = ''
             if self.include_error_context:
                 context = self._find_context(out)
-            return out, context, before_file_hash
+
+            return exit_code, out, context, before_file_hash
         except Exception:
             traceback.print_exc()
-            return '', '', ''
+            return -1, '', '', ''
         finally:
             self._proc = None
 

--- a/mypytools/server/mypy_worker.py
+++ b/mypytools/server/mypy_worker.py
@@ -36,7 +36,7 @@ class MypyWorker(BaseThread):
         self.current_task = self._task_pool.pop(0)
         self._task_cond.release()
 
-        output, full_context, file_hash = self.current_task.execute()
+        exit_code, output, full_context, file_hash = self.current_task.execute()
 
         self._task_cond.acquire()
         self.file_cache.store(self.current_task.filename, file_hash, output)
@@ -47,6 +47,8 @@ class MypyWorker(BaseThread):
             else:
                 sys.stdout.write(full_context)
             sys.stdout.flush()
+        else:
+            assert exit_code == 0
         self._task_cond.notify_all()
         self._task_cond.release()
 


### PR DESCRIPTION
This will allow clients of MypyTask to detect if the underlying mypy
process exited with an error even if it didn't emit any output.