### PR TITLE
Handle block strings in decorators

### DIFF
--- a/mypytools/source_utils.py
+++ b/mypytools/source_utils.py
@@ -55,7 +55,8 @@ def find_final_line_including_parens(lines, line_num):
                 escape_char = False
 
             # This isn't an escaped character so check for the end of the string.
-            elif line[loc] == string_char:
+            # The substring-ing part of this check is to handle the end of block strings.
+            elif line[loc:loc + len(string_char)] == string_char:
                 string_char = None
 
             # While inside a string skip the contents.
@@ -64,7 +65,11 @@ def find_final_line_including_parens(lines, line_num):
 
         # Check for the beginning of a string.
         if line[loc] in '\'"':
-            string_char = line[loc]
+            # Handle block strings.
+            if line[loc:loc + 3] == line[loc] * 3:
+                string_char = line[loc] * 3
+            else:
+                string_char = line[loc]
 
         # Check for the beginning of a comment, advance to end of line.
         elif line[loc] == '#':

--- a/tests/test_check_mypy_annotations.py
+++ b/tests/test_check_mypy_annotations.py
@@ -171,6 +171,23 @@ def test(foo, bar, expected):
     assert len(error_lines) == 0
 
 
+def test_multiline_decorator_with_blockstring():
+    # type: () -> None
+    source = """
+@foo([
+    \"\"\"
+    foo bar baz ")
+    \"\"\"
+])
+def test(foo, bar, expected):
+    # type: (float, int, bool) -> None
+    pass
+
+"""
+    error_lines = get_error_lines(source, {9})
+    assert len(error_lines) == 0
+
+
 def test_correct_offset():
     # type: () -> None
     source = """


### PR DESCRIPTION
We only handled single-quoted strings, but we need to be able to handle
block strings too.